### PR TITLE
Migrate tests dashboard to eCharts

### DIFF
--- a/backend/ccfatigue/utils/echarts_plots.py
+++ b/backend/ccfatigue/utils/echarts_plots.py
@@ -1,0 +1,346 @@
+import os
+import numpy as np
+import pandas as pd
+from enum import Enum
+from typing import List, Dict, Any, Optional
+from pydantic import BaseModel
+from bokeh import palettes
+from pandas.core.frame import DataFrame
+from sqlalchemy.future import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from ccfatigue.models.database import Experiment, Test
+
+DATA_DIRECTORY: str = "../fake_data/"
+
+INTERVAL: int = 10
+LOOP_SPACING: int = 1000
+MAGNITUDE: int = -3
+
+
+class TestPlot(BaseModel):
+    """
+    Defines Test metadata related to a plot
+    """
+
+    test_id: int
+    specimen_id: int
+    color: str
+    total_dissipated_energy: int
+
+
+class Plots(BaseModel):
+    """
+    Defines all plots types returned
+    """
+
+    stress_strain: Any
+    creep: Any
+    hysteresis_area: Any
+    stiffness: Any
+
+
+class DashboardPlots(BaseModel):
+    """
+    Defines data returned to the dashboard
+    """
+
+    tests: List[TestPlot]
+    plots: Plots
+
+
+class TopicName(Enum):
+    """
+    Defines matching between each topic and it's end user name
+    """
+
+    CREEP = ("creep", "Creep")
+    HIGH = ("high", "High")
+    HYST_AREA = ("hyst_area", "Hysteresis area")
+    LOW = ("low", "Low")
+    N_CYCLES = ("n_cycles", "Number of cycles")
+    R_RATIO = ("r_ratio", "R ratio")
+    STIFNESS = ("stiffness", "Stiffness")
+    STRAIN = ("strain", "Strain")
+    STRESS = ("stress", "Stress")
+    STRESS_PARAM = ("stress_parameter", "Maximum Cyclic Stress")
+
+    def __init__(self, key: str, label: str):
+        self.key = key
+        self.label = label
+
+
+class Line(BaseModel):
+    """
+    Defines how each plot's line is described
+    """
+
+    data: Dict[str, List[Any]]
+    legend_label: Optional[str]
+    color: Optional[str]
+
+
+class Plot(BaseModel):
+    """
+    Defines how each plot is described
+    """
+
+    title: str
+    x_axis: TopicName
+    y_axis: TopicName
+    tooltips: List[TopicName]
+    lines: List[Line] = []
+    x_axis_type: str = "auto"
+    y_axis_type: str = "auto"
+
+    class Config:
+        use_enum_values = True
+
+
+def encoderNp(obj):
+    if isinstance(obj, np.integer):
+        return int(obj)
+    if isinstance(obj, np.floating):
+        return float(obj)
+    if isinstance(obj, np.ndarray):
+        return obj.tolist()
+    else:
+        return obj
+
+
+def get_dataframe(
+    data_in: str,
+    exp: Dict,
+    specimen_id: int,
+) -> DataFrame:
+    """
+    return extracted DataFrame related to that test from CSV
+    """
+    filename = f"{data_in}_{exp['date']}_{exp['experiment_type']}_{specimen_id:03d}.csv"
+    filepath = os.path.join(
+        DATA_DIRECTORY,
+        exp["laboratory"],
+        exp["researcher"],
+        exp["experiment_type"],
+        exp["date"],
+        data_in,
+        filename,
+    )
+    return pd.read_csv(os.path.abspath(filepath))
+
+
+def compute_sub_indexes(df: DataFrame) -> List[int]:
+    """
+    Compute subset of index used for plotting curves
+    """
+    n_cycles_max = np.max(df.n_cycles)
+
+    sub_index_intermediate = np.geomspace(
+        start=LOOP_SPACING, stop=n_cycles_max, num=INTERVAL
+    )
+    sub_index = np.round(sub_index_intermediate, MAGNITUDE)
+    sub_index[0] = 1
+
+    return sub_index
+
+
+def create_sub_hystloops(
+    df: DataFrame, sub_index: List[int]
+) -> List[Dict[TopicName, List]]:
+    """
+    Conditional plotting of hysteresis loops
+    we only plot the loops specified by sub_index
+    """
+    sub_hystloops = []
+    for j in range(len(sub_index)):
+        sub_hystloops_strain = []
+        sub_hystloops_stress = []
+        sub_hystloops_ncycles = []
+        for i in range(len(df)):
+            if df.Machine_N_cycles[i] == sub_index[j]:
+                sub_hystloops_strain.append(df.Machine_Displacement[i])
+                sub_hystloops_stress.append(df.Machine_Load[i])
+                sub_hystloops_ncycles.append(df.Machine_N_cycles[i])
+        # make curve closed // Optional
+        if len(sub_hystloops_ncycles) != 0:
+            sub_hystloops_strain.append(sub_hystloops_strain[0])
+            sub_hystloops_stress.append(sub_hystloops_stress[0])
+            sub_hystloops_ncycles.append(sub_hystloops_ncycles[0])
+
+        sub_hystloops.append(
+            {
+                TopicName.N_CYCLES.key: sub_hystloops_ncycles,
+                TopicName.STRAIN.key: sub_hystloops_strain,
+                TopicName.STRESS.key: sub_hystloops_stress,
+            }
+        )
+    return sub_hystloops
+
+
+def generate_data_to_plot_stress_strain(
+    tests: List[TestPlot], std_dfs: List[DataFrame], hyst_dfs: List[DataFrame]
+) -> Plot:
+    """
+    return data used to generated plot "Stress - Strain"
+    """
+    sub_hystloops = [
+        create_sub_hystloops(std_df, compute_sub_indexes(hyst_df))
+        for std_df, hyst_df in zip(std_dfs, hyst_dfs)
+    ]
+    lines = [
+        Line(
+            data=loop,
+            legend_label=test.specimen_id,
+            color=test.color,
+        )
+        for test, loops in zip(tests, sub_hystloops)
+        for loop in loops
+    ]
+    return Plot(
+        title="Stress - Strain",
+        x_axis=TopicName.STRAIN,
+        y_axis=TopicName.STRESS,
+        tooltips=[TopicName.STRESS, TopicName.STRAIN, TopicName.N_CYCLES],
+        lines=lines,
+    )
+
+
+def generate_data_to_plot_creep(
+    tests: List[TestPlot], hyst_dfs: List[DataFrame]
+) -> Plot:
+    """
+    return data used to generated plot "Creep evolution"
+    """
+    lines = [
+        Line(
+            data={
+                TopicName.N_CYCLES.key: hyst_df["n_cycles"].to_list(),
+                TopicName.CREEP.key: hyst_df["creep"].to_list(),
+            },
+            legend_label=test.specimen_id,
+            color=test.color,
+        )
+        for test, hyst_df in zip(tests, hyst_dfs)
+    ]
+    return Plot(
+        title="Creep evolution",
+        x_axis=TopicName.N_CYCLES,
+        y_axis=TopicName.CREEP,
+        tooltips=[TopicName.CREEP, TopicName.N_CYCLES],
+        lines=lines,
+    )
+
+
+def generate_data_to_plot_hyst_area(
+    tests: List[TestPlot], hyst_dfs: List[DataFrame]
+) -> Plot:
+    """
+    return data used to generated plot "Hysteresis loop area evolution"
+    """
+    lines = [
+        Line(
+            data={
+                TopicName.N_CYCLES.key: hyst_df["n_cycles"].to_list(),
+                TopicName.HYST_AREA.key: hyst_df["hysteresis_area"].to_list(),
+            },
+            legend_label=test.specimen_id,
+            color=test.color,
+        )
+        for test, hyst_df in zip(tests, hyst_dfs)
+    ]
+    return Plot(
+        title="Hysteresis loop area evolution",
+        x_axis=TopicName.N_CYCLES,
+        y_axis=TopicName.HYST_AREA,
+        tooltips=[TopicName.HYST_AREA, TopicName.N_CYCLES],
+        lines=lines,
+    )
+
+
+def generate_data_to_plot_stiffness(
+    tests: List[TestPlot], hyst_dfs: List[DataFrame]
+) -> Plot:
+    """
+    return data used to generated plot "Stiffness evolution under cyclic loading"
+    """
+    lines = [
+        Line(
+            data={
+                TopicName.N_CYCLES.key: hyst_df["n_cycles"].to_list(),
+                TopicName.STIFNESS.key: hyst_df["stiffness"].to_list(),
+            },
+            legend_label=test.specimen_id,
+            color=test.color,
+        )
+        for test, hyst_df in zip(tests, hyst_dfs)
+    ]
+    return Plot(
+        title="Stiffness evolution under cyclic loading",
+        x_axis=TopicName.N_CYCLES,
+        y_axis=TopicName.STIFNESS,
+        tooltips=[TopicName.STIFNESS, TopicName.N_CYCLES],
+        lines=lines,
+    )
+
+
+def get_total_dissipated_energy(hyst_df: DataFrame) -> int:
+    """
+    return calculated Total Dissipated Energy (TDE)
+    """
+    return np.sum(hyst_df["hysteresis_area"])
+
+
+async def generate_data_tests_dashboard_plots(
+    session: AsyncSession, experiment_id: int, test_ids: List[int]
+) -> DashboardPlots:
+    """
+    Generate  data for the 4 plots displayed in the Tests Dashboard view
+    """
+    colors = list(palettes.Category10_10)[: len(test_ids)]
+    exp = dict(
+        zip(
+            ("laboratory", "researcher", "experiment_type", "date"),
+            list(
+                await session.execute(
+                    select(
+                        Experiment.laboratory,
+                        Experiment.researcher,
+                        Experiment.experiment_type,
+                        Experiment.date,
+                    ).where(Experiment.id == experiment_id)
+                )
+            )[0],
+        )
+    )
+    test_2_specimen = {
+        entry.id: entry.specimen_number
+        for entry in list(
+            await session.execute(
+                select(Test.id, Test.specimen_number).where(
+                    Test.experiment_id == experiment_id
+                )
+            )
+        )
+    }
+    specimen_ids = [int(test_2_specimen[test_id]) for test_id in test_ids]
+    std_dfs = [get_dataframe("STD", exp, specimen_id) for specimen_id in specimen_ids]
+    hyst_dfs = [get_dataframe("HYS", exp, specimen_id) for specimen_id in specimen_ids]
+    tests = [
+        TestPlot(
+            test_id=test_id,
+            specimen_id=specimen_id,
+            color=color,
+            total_dissipated_energy=get_total_dissipated_energy(hyst_df),
+        )
+        for test_id, specimen_id, color, hyst_df in zip(
+            test_ids, specimen_ids, colors, hyst_dfs
+        )
+    ]
+    return DashboardPlots(
+        tests=tests,
+        plots=Plots(
+            stress_strain=generate_data_to_plot_stress_strain(tests, std_dfs, hyst_dfs),
+            creep=generate_data_to_plot_creep(tests, hyst_dfs),
+            hysteresis_area=generate_data_to_plot_hyst_area(tests, hyst_dfs),
+            stiffness=generate_data_to_plot_stiffness(tests, hyst_dfs),
+        ),
+    )

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "@openapitools/openapi-generator-cli": "^2.4.18",
     "core-js": "^3.6.5",
     "downloadjs": "^1.4.7",
+    "echarts": "^5.3.3",
     "numeral": "^2.0.6",
     "superagent": "^6.1.0",
     "vue": "^2.6.11",

--- a/frontend/src/backend/README.md
+++ b/frontend/src/backend/README.md
@@ -115,14 +115,15 @@ api.getUnitsUnitsGet(callback);
 
 All URIs are relative to _http://localhost_
 
-| Class                      | Method                                                                                                                                        | HTTP request                               | Description               |
-| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ | ------------------------- |
-| _Ccfatigue.DefaultApi_     | [**getUnitsUnitsGet**](docs/DefaultApi.md#getUnitsUnitsGet)                                                                                   | **GET** /units                             | Get Units                 |
-| _Ccfatigue.DefaultApi_     | [**rootGet**](docs/DefaultApi.md#rootGet)                                                                                                     | **GET** /                                  | Root                      |
-| _Ccfatigue.ExperimentsApi_ | [**getExperimentsExperimentsGet**](docs/ExperimentsApi.md#getExperimentsExperimentsGet)                                                       | **GET** /experiments                       | Get Experiments           |
-| _Ccfatigue.ExperimentsApi_ | [**getFieldDistinctExperimentsFieldDistinctGet**](docs/ExperimentsApi.md#getFieldDistinctExperimentsFieldDistinctGet)                         | **GET** /experiments/{field}/distinct      | Get Field Distinct        |
-| _Ccfatigue.ExperimentsApi_ | [**getTestsDashboardPlotsExperimentsTestsDashboardPlotsGet**](docs/ExperimentsApi.md#getTestsDashboardPlotsExperimentsTestsDashboardPlotsGet) | **GET** /experiments/tests_dashboard_plots | Get Tests Dashboard Plots |
-| _Ccfatigue.TestsApi_       | [**getTestsTestsGet**](docs/TestsApi.md#getTestsTestsGet)                                                                                     | **GET** /tests                             | Get Tests                 |
+| Class                      | Method                                                                                                                                                        | HTTP request                                    | Description                    |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- | ------------------------------ |
+| _Ccfatigue.DefaultApi_     | [**getUnitsUnitsGet**](docs/DefaultApi.md#getUnitsUnitsGet)                                                                                                   | **GET** /units                                  | Get Units                      |
+| _Ccfatigue.DefaultApi_     | [**rootGet**](docs/DefaultApi.md#rootGet)                                                                                                                     | **GET** /                                       | Root                           |
+| _Ccfatigue.ExperimentsApi_ | [**getDataTestsDashboardPlotsExperimentsDataTestsDashboardPlotsGet**](docs/ExperimentsApi.md#getDataTestsDashboardPlotsExperimentsDataTestsDashboardPlotsGet) | **GET** /experiments/data_tests_dashboard_plots | Get Data Tests Dashboard Plots |
+| _Ccfatigue.ExperimentsApi_ | [**getExperimentsExperimentsGet**](docs/ExperimentsApi.md#getExperimentsExperimentsGet)                                                                       | **GET** /experiments                            | Get Experiments                |
+| _Ccfatigue.ExperimentsApi_ | [**getFieldDistinctExperimentsFieldDistinctGet**](docs/ExperimentsApi.md#getFieldDistinctExperimentsFieldDistinctGet)                                         | **GET** /experiments/{field}/distinct           | Get Field Distinct             |
+| _Ccfatigue.ExperimentsApi_ | [**getTestsDashboardPlotsExperimentsTestsDashboardPlotsGet**](docs/ExperimentsApi.md#getTestsDashboardPlotsExperimentsTestsDashboardPlotsGet)                 | **GET** /experiments/tests_dashboard_plots      | Get Tests Dashboard Plots      |
+| _Ccfatigue.TestsApi_       | [**getTestsTestsGet**](docs/TestsApi.md#getTestsTestsGet)                                                                                                     | **GET** /tests                                  | Get Tests                      |
 
 ## Documentation for Models
 

--- a/frontend/src/backend/docs/ExperimentsApi.md
+++ b/frontend/src/backend/docs/ExperimentsApi.md
@@ -2,11 +2,62 @@
 
 All URIs are relative to _http://localhost_
 
-| Method                                                                                                                                   | HTTP request                               | Description               |
-| ---------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ | ------------------------- |
-| [**getExperimentsExperimentsGet**](ExperimentsApi.md#getExperimentsExperimentsGet)                                                       | **GET** /experiments                       | Get Experiments           |
-| [**getFieldDistinctExperimentsFieldDistinctGet**](ExperimentsApi.md#getFieldDistinctExperimentsFieldDistinctGet)                         | **GET** /experiments/{field}/distinct      | Get Field Distinct        |
-| [**getTestsDashboardPlotsExperimentsTestsDashboardPlotsGet**](ExperimentsApi.md#getTestsDashboardPlotsExperimentsTestsDashboardPlotsGet) | **GET** /experiments/tests_dashboard_plots | Get Tests Dashboard Plots |
+| Method                                                                                                                                                   | HTTP request                                    | Description                    |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- | ------------------------------ |
+| [**getDataTestsDashboardPlotsExperimentsDataTestsDashboardPlotsGet**](ExperimentsApi.md#getDataTestsDashboardPlotsExperimentsDataTestsDashboardPlotsGet) | **GET** /experiments/data_tests_dashboard_plots | Get Data Tests Dashboard Plots |
+| [**getExperimentsExperimentsGet**](ExperimentsApi.md#getExperimentsExperimentsGet)                                                                       | **GET** /experiments                            | Get Experiments                |
+| [**getFieldDistinctExperimentsFieldDistinctGet**](ExperimentsApi.md#getFieldDistinctExperimentsFieldDistinctGet)                                         | **GET** /experiments/{field}/distinct           | Get Field Distinct             |
+| [**getTestsDashboardPlotsExperimentsTestsDashboardPlotsGet**](ExperimentsApi.md#getTestsDashboardPlotsExperimentsTestsDashboardPlotsGet)                 | **GET** /experiments/tests_dashboard_plots      | Get Tests Dashboard Plots      |
+
+## getDataTestsDashboardPlotsExperimentsDataTestsDashboardPlotsGet
+
+> DashboardPlots getDataTestsDashboardPlotsExperimentsDataTestsDashboardPlotsGet(opts)
+
+Get Data Tests Dashboard Plots
+
+Return data for the 4 echarts plots used in Test Dashboard Note: this serves the same data as get_test_dashboard_plots, and was created to migrate to echarts, if successful the Bokeh utils and routes should be removed Warning : this serves _data_ not Bokeh plots themselves
+
+### Example
+
+```javascript
+import Ccfatigue from "ccfatigue";
+
+let apiInstance = new Ccfatigue.ExperimentsApi();
+let opts = {
+  experimentId: 56, // Number |
+  testIds: [null], // [Number] |
+};
+apiInstance.getDataTestsDashboardPlotsExperimentsDataTestsDashboardPlotsGet(
+  opts,
+  (error, data, response) => {
+    if (error) {
+      console.error(error);
+    } else {
+      console.log("API called successfully. Returned data: " + data);
+    }
+  }
+);
+```
+
+### Parameters
+
+| Name             | Type                      | Description | Notes      |
+| ---------------- | ------------------------- | ----------- | ---------- |
+| **experimentId** | **Number**                |             | [optional] |
+| **testIds**      | [**[Number]**](Number.md) |             | [optional] |
+
+### Return type
+
+[**DashboardPlots**](DashboardPlots.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/json
 
 ## getExperimentsExperimentsGet
 

--- a/frontend/src/backend/src/api/ExperimentsApi.js
+++ b/frontend/src/backend/src/api/ExperimentsApi.js
@@ -35,6 +35,59 @@ export default class ExperimentsApi {
   }
 
   /**
+   * Callback function to receive the result of the getDataTestsDashboardPlotsExperimentsDataTestsDashboardPlotsGet operation.
+   * @callback module:api/ExperimentsApi~getDataTestsDashboardPlotsExperimentsDataTestsDashboardPlotsGetCallback
+   * @param {String} error Error message, if any.
+   * @param {module:model/DashboardPlots} data The data returned by the service call.
+   * @param {String} response The complete HTTP response.
+   */
+
+  /**
+   * Get Data Tests Dashboard Plots
+   * Return data for the 4 echarts plots used in Test Dashboard  Note: this serves the same data as get_test_dashboard_plots, and was created to migrate to echarts, if successful the Bokeh utils and routes should be removed Warning : this serves *data* not Bokeh plots themselves
+   * @param {Object} opts Optional parameters
+   * @param {Number} opts.experimentId
+   * @param {Array.<Number>} opts.testIds
+   * @param {module:api/ExperimentsApi~getDataTestsDashboardPlotsExperimentsDataTestsDashboardPlotsGetCallback} callback The callback function, accepting three arguments: error, data, response
+   * data is of type: {@link module:model/DashboardPlots}
+   */
+  getDataTestsDashboardPlotsExperimentsDataTestsDashboardPlotsGet(
+    opts,
+    callback
+  ) {
+    opts = opts || {};
+    let postBody = null;
+
+    let pathParams = {};
+    let queryParams = {
+      experiment_id: opts["experimentId"],
+      test_ids: this.apiClient.buildCollectionParam(opts["testIds"], "multi"),
+    };
+    let headerParams = {};
+    let formParams = {};
+
+    let authNames = [];
+    let contentTypes = [];
+    let accepts = ["application/json"];
+    let returnType = DashboardPlots;
+    return this.apiClient.callApi(
+      "/experiments/data_tests_dashboard_plots",
+      "GET",
+      pathParams,
+      queryParams,
+      headerParams,
+      formParams,
+      postBody,
+      authNames,
+      contentTypes,
+      accepts,
+      returnType,
+      null,
+      callback
+    );
+  }
+
+  /**
    * Callback function to receive the result of the getExperimentsExperimentsGet operation.
    * @callback module:api/ExperimentsApi~getExperimentsExperimentsGetCallback
    * @param {String} error Error message, if any.

--- a/frontend/src/backend/test/api/ExperimentsApi.spec.js
+++ b/frontend/src/backend/test/api/ExperimentsApi.spec.js
@@ -44,6 +44,16 @@
   };
 
   describe("ExperimentsApi", function () {
+    describe("getDataTestsDashboardPlotsExperimentsDataTestsDashboardPlotsGet", function () {
+      it("should call getDataTestsDashboardPlotsExperimentsDataTestsDashboardPlotsGet successfully", function (done) {
+        //uncomment below and update the code to test getDataTestsDashboardPlotsExperimentsDataTestsDashboardPlotsGet
+        //instance.getDataTestsDashboardPlotsExperimentsDataTestsDashboardPlotsGet(function(error) {
+        //  if (error) throw error;
+        //expect().to.be();
+        //});
+        done();
+      });
+    });
     describe("getExperimentsExperimentsGet", function () {
       it("should call getExperimentsExperimentsGet successfully", function (done) {
         //uncomment below and update the code to test getExperimentsExperimentsGet

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -7,6 +7,8 @@ import numeral from "numeral";
 import numFormat from "vue-filter-number-format";
 
 Vue.config.productionTip = false;
+// allow devtools if developping env
+if (process.env.NODE_ENV === "development") Vue.config.devtools = true;
 
 numeral.register("locale", "fr-CH", {
   delimiters: {

--- a/frontend/src/store/echartsPlots.js
+++ b/frontend/src/store/echartsPlots.js
@@ -1,0 +1,36 @@
+export default {
+  namespaced: true,
+  state: {
+    loading: false,
+    tests: [],
+    plots: {},
+  },
+  mutations: {
+    nowWeLoad(state) {
+      state.loading = true;
+    },
+    storeEchartsPlots(state, data) {
+      state.tests = data.tests;
+      state.plots = data.plots;
+      state.loading = false;
+    },
+  },
+  actions: {
+    fetchEchartsPlots({ commit }, payload) {
+      commit("nowWeLoad", payload);
+      this._vm.$experimentsApi.getDataTestsDashboardPlotsExperimentsDataTestsDashboardPlotsGet(
+        {
+          experimentId: payload.experimentId,
+          testIds: payload.testIds,
+        },
+        (error, data) => {
+          if (error) {
+            console.error(error);
+          } else {
+            commit("storeEchartsPlots", data);
+          }
+        }
+      );
+    },
+  },
+};

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -5,6 +5,7 @@ import { DefaultApi, ExperimentsApi, TestsApi } from "@/backend/src/index";
 import ApiClient from "@/backend/src/ApiClient";
 import experiments from "./experiments";
 import bokehPlots from "./bokehPlots";
+import echartsPlots from "./echartsPlots";
 
 Vue.use(Vuex);
 
@@ -17,5 +18,6 @@ export default new Vuex.Store({
   modules: {
     experiments,
     bokehPlots,
+    echartsPlots,
   },
 });

--- a/openapi.json
+++ b/openapi.json
@@ -170,6 +170,63 @@
         }
       }
     },
+    "/experiments/data_tests_dashboard_plots": {
+      "get": {
+        "tags": [
+          "experiments"
+        ],
+        "summary": "Get Data Tests Dashboard Plots",
+        "description": "Return data for the 4 echarts plots used in Test Dashboard\n\nNote: this serves the same data as get_test_dashboard_plots, and was created to migrate to echarts, if successful the Bokeh utils and routes should be removed\nWarning : this serves *data* not Bokeh plots themselves",
+        "operationId": "get_data_tests_dashboard_plots_experiments_data_tests_dashboard_plots_get",
+        "parameters": [
+          {
+            "required": false,
+            "schema": {
+              "title": "Experiment Id",
+              "type": "integer",
+              "default": ""
+            },
+            "name": "experiment_id",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "title": "Test Ids",
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "default": []
+            },
+            "name": "test_ids",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardPlots"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/experiments/tests_dashboard_plots": {
       "get": {
         "tags": [


### PR DESCRIPTION
Refering to [previous comment on issue](https://github.com/EPFL-ENAC/CCFatiguePlatform/issues/35#issuecomment-1195784612) 

Backend : 

- I decided to create new API endpoint to fetch data for the dashboard, indeed previous API endpoint was returning Bokeh specific JSON data. For simplicity I created a new utility file similar to utils/bokeh_plots, only serving plain JSON data.
- We are feeding data from a hardcoded CSV file, I didn't change this method but I would suggest to serve data from the database directly (hence we would need to populate database with the tests data). We could also change the routes for a more REST compliant API.
- If you want I could create a new pull request without any reference to bokeh (since it's no use anymore)

Frontend:
- I tried to change as little as possible, so only installed echarts (I found vue-echarts which might make the code cleaner). I re-used the logic already created for the dashboard (how it connects to store etc). I only adapted to use echarts instead of Bokeh. - I also have some suggestions, for example we could move the vertical "info" colonne to horizontal  to get more space for the charts
- Also moving the info tooltip button inside the echarts : there is an included toolbox that could save us space
