### PR TITLE
docs/119 markdown cleanup

### DIFF
--- a/Data/AGG_Data_Convention.md
+++ b/Data/AGG_Data_Convention.md
@@ -1,8 +1,10 @@
 # AGG Standard Data format
 
 AGG Data constitutes input of S-N Curve module, together with
-* ASTM.csv, available from https://www.astm.org/stp313-eb.html pp 20-23
-* Reliability level parameter (RELIABILITY_LEVEL P(N) with value [0,1], default value : 0.5)
+
+- ASTM.csv, available from https://www.astm.org/stp313-eb.html pp 20-23
+- Reliability level parameter (RELIABILITY_LEVEL P(N) with value \[0,1\], default value : 0.5)
+
 ### File naming conventions
 
 - File: `AGG_{Researcher's lastname}_{Date}_{Test type}.csv`
@@ -15,12 +17,10 @@ with:
 
 Encoding format: UTF-8, Separator: ',' (comma)
 
-
-| Variable name         | Description                                             | Symbol    | Unit  | Data type | Mandatory       |
-| --------------------- | ------------------------------------------------------- | --------- | ----- | --------- | --------------- |
-| stress_ratio          | Stress ratio                                            | R         | [-]   | double    | y               |
-| stress_cluster_number | Index of the cluster of stress level for Whitney method |           | [-]   | int       | y               |
-| stress_max            | Max stress                                              | sigma_max | [MPa] | double    | y               |
-| cycles_to_failure     | Number of cycles to failure                             | N         | [-]   | int       | y               |
-| residual_strength     | Residual strength                                       | sigma_r   | [MPa] | double    | y for Sendeckyj |
-
+| Variable name         | Description                                             | Symbol    | Unit    | Data type | Mandatory       |
+| --------------------- | ------------------------------------------------------- | --------- | ------- | --------- | --------------- |
+| stress_ratio          | Stress ratio wijer                                      | R         | `[-]`   | double    | y               |
+| stress_cluster_number | Index of the cluster of stress level for Whitney method |           | `[-]`   | int       | y               |
+| stress_max            | Max stress                                              | sigma_max | `[MPa]` | double    | y               |
+| cycles_to_failure     | Number of cycles to failure                             | N         | `[-]`   | int       | y               |
+| residual_strength     | Residual strength                                       | sigma_r   | `[MPa]` | double    | y for Sendeckyj |

--- a/Data/CLD_Data_Convention.md
+++ b/Data/CLD_Data_Convention.md
@@ -2,6 +2,7 @@
 
 Note: in all the Fortran codes, the output range of mean stress needs to be checked and tuned!
 CLD Data is the output of the Constant-Life Diagram module.
+
 ## File naming conventions
 
 - Files: `CLD_{Researcher's lastname}_{Date}.json`
@@ -15,8 +16,8 @@ with:
 
 Encoding format: UTF-8, Separator: ',' (comma)
 
-| Variable name     | Description                 | Symbol     | Unit  | Data type | Mandatory |
-| ----------------- | --------------------------- | ---------- | ----- | --------- | --------- |
-| cycles_to_failure | Number of cycles to failure | N          | [-]   | int       | y         |
-| stress_amplitude  | Stress amplitude            | sigma_a    | [MPa] | double    | y         |
-| stress_mean       | Mean stress                 | sigma_mean | [MPa] | double    | y         |
+| Variable name     | Description                 | Symbol     | Unit    | Data type | Mandatory |
+| ----------------- | --------------------------- | ---------- | ------- | --------- | --------- |
+| cycles_to_failure | Number of cycles to failure | N          | `[-]`   | int       | y         |
+| stress_amplitude  | Stress amplitude            | sigma_a    | `[MPa]` | double    | y         |
+| stress_mean       | Mean stress                 | sigma_mean | `[MPa]` | double    | y         |

--- a/Data/CYC_Data_Convention.md
+++ b/Data/CYC_Data_Convention.md
@@ -1,5 +1,7 @@
 # CYC Standard Data format
+
 CYC Data is the output of the Cycle Counting module.
+
 ### File naming conventions
 
 - File: `CYC_{Researcher's lastname}_{Date}.csv`
@@ -12,10 +14,10 @@ with:
 
 Encoding format: UTF-8, Separator: ',' (comma)
 
-| Variable name | Description                                                               | Symbol      | Unit  | Data type | Mandatory |
-| ------------- | ------------------------------------------------------------------------- | ----------- | ----- | --------- | --------- |
-| stress_range  | Stress range (= 2 \* sigma_a)                                             | delta_sigma | [MPa] | double    | y         |
-| stress_mean   | Mean stress                                                               | sigma_mean  | [MPa] | double    | y         |
-| stress_ratio  | Stress ratio                                                              | R           | [-]   | double    | y         |
-| n_cycles      | Number of cycles                                                          | n           |       | double    | y         |
-| cum_n_cycles  | cumulative number of cycles for a given bin of sigma_a, sigma_mean and R. |             |       | double    | y         |
+| Variable name | Description                                                               | Symbol      | Unit    | Data type | Mandatory |
+| ------------- | ------------------------------------------------------------------------- | ----------- | ------- | --------- | --------- |
+| stress_range  | Stress range (= `2 * sigma_a`)                                            | delta_sigma | `[MPa]` | double    | y         |
+| stress_mean   | Mean stress                                                               | sigma_mean  | `[MPa]` | double    | y         |
+| stress_ratio  | Stress ratio                                                              | R           | `[-]`   | double    | y         |
+| n_cycles      | Number of cycles                                                          | n           |         | double    | y         |
+| cum_n_cycles  | cumulative number of cycles for a given bin of sigma_a, sigma_mean and R. |             |         | double    | y         |

--- a/Data/DAS_Data_Convention.md
+++ b/Data/DAS_Data_Convention.md
@@ -2,6 +2,7 @@
 
 Note: Currently module 5 re-runs module 3 inside module 5. Needs to be updated.
 DAS Data corresponds to the output of Damage summation module.
+
 ## File naming conventions
 
 - Files: `DAS_{Researcher's lastname}_{Date}.json`
@@ -15,7 +16,7 @@ with:
 
 Encoding format: UTF-8, Separator: ',' (comma)
 
-| Variable name | Description | Symbol    | Unit  | Data type | Mandatory |
-| ------------- | ----------- | --------- | ----- | --------- | --------- |
-| stress_max    | Max stress  | sigma_max | [MPa] | double    | y         |
-| damage        | Damage      | D         | [-]   | double    | y         |
+| Variable name | Description | Symbol    | Unit    | Data type | Mandatory |
+| ------------- | ----------- | --------- | ------- | --------- | --------- |
+| stress_max    | Max stress  | sigma_max | `[MPa]` | double    | y         |
+| damage        | Damage      | D         | `[-]`   | double    | y         |

--- a/Data/FAF_Data_Convention.md
+++ b/Data/FAF_Data_Convention.md
@@ -1,5 +1,7 @@
 # FAF Standard Data format
+
 FAF Data corresponds to the output of Fatigue failure module.
+
 ## File naming conventions
 
 - Files: `FAF_{Researcher's lastname}_{Date}.json`
@@ -33,8 +35,8 @@ Encoding format: UTF-8
 
 Encoding format: UTF-8, Separator: ',' (comma)
 
-| Variable name     | Description                 | Symbol    | Unit  | Data type | Mandatory |
-| ----------------- | --------------------------- | --------- | ----- | --------- | --------- |
-| stress_ratio      | Stress ratio                | R         | [-]   | double    | y         |
-| cycles_to_failure | Number of cycles to failure | N         | [-]   | int       | y         |
-| stress_max        | Max stress                  | sigma_max | [MPa] | double    | y         |
+| Variable name     | Description                 | Symbol    | Unit    | Data type | Mandatory |
+| ----------------- | --------------------------- | --------- | ------- | --------- | --------- |
+| stress_ratio      | Stress ratio                | R         | `[-]`   | double    | y         |
+| cycles_to_failure | Number of cycles to failure | N         | `[-]`   | int       | y         |
+| stress_max        | Max stress                  | sigma_max | `[MPa]` | double    | y         |

--- a/Data/LDS_Data_Convention.md
+++ b/Data/LDS_Data_Convention.md
@@ -14,6 +14,6 @@ with:
 
 Encoding format: UTF-8, Separator: ',' (comma)
 
-| Variable name | Description | Symbol    | Unit  | Data type | Mandatory |
-| ------------- | ----------- | --------- | ----- | --------- | --------- |
-| stress_max    | Max stress  | sigma_max | [MPa] | double    | y         |
+| Variable name | Description | Symbol    | Unit    | Data type | Mandatory |
+| ------------- | ----------- | --------- | ------- | --------- | --------- |
+| stress_max    | Max stress  | sigma_max | `[MPa]` | double    | y         |

--- a/Data/SNC_Data_Convention.md
+++ b/Data/SNC_Data_Convention.md
@@ -1,4 +1,5 @@
 # SNC Standard Data format
+
 SNC Data corresponds to the output of S-N Curve module and is composed of 2 files :
 
 - one json file containing the different R-ratio with some parameters reserved for the software
@@ -35,10 +36,10 @@ Encoding format: UTF-8
 
 Encoding format: UTF-8, Separator: ',' (comma)
 
-| Variable name     | Description                     | Symbol    | Unit  | Data type | Mandatory |
-| ----------------- | ------------------------------- | --------- | ----- | --------- | --------- |
-| stress_ratio      | Stress ratio                    | R         | [-]   | double    | y         |
-| cycles_to_failure | Number of cycles to failure     | N         | [-]   | int       | y         |
-| stress_max        | Max stress                      | sigma_max | [MPa] | double    | y         |
-| stress_lowerbound | Stress at failure (lower bound) | sigma_max | [MPa] | double    |           |
-| stress_upperbound | Stress at failure (upper bound) | sigma_max | [MPa] | double    |           |
+| Variable name     | Description                     | Symbol    | Unit    | Data type | Mandatory |
+| ----------------- | ------------------------------- | --------- | ------- | --------- | --------- |
+| stress_ratio      | Stress ratio                    | R         | `[-]`   | double    | y         |
+| cycles_to_failure | Number of cycles to failure     | N         | `[-]`   | int       | y         |
+| stress_max        | Max stress                      | sigma_max | `[MPa]` | double    | y         |
+| stress_lowerbound | Stress at failure (lower bound) | sigma_max | `[MPa]` | double    |           |
+| stress_upperbound | Stress at failure (upper bound) | sigma_max | `[MPa]` | double    |           |

--- a/Data/TST_Data_Convention.md
+++ b/Data/TST_Data_Convention.md
@@ -35,37 +35,37 @@ In the Excel metadata template, note that only row 4 (sheet 1) and row 3 (sheet 
 
 ## TST CSV files standards (column names must be exact) :
 
-| Column name            | Description                                           | Unit  | Data type | Mandatory | Multiple measurement points |
-| ---------------------- | ----------------------------------------------------- | ----- | --------- | --------- | --------------------------- |
-| `Machine_Time`         | Absolute or relative time recorded by the machine     | [-]   | string    |           |                             |
-| `Machine_N_cycles`     | Number of cycles counted by the machine               | [-]   | int       |           |                             |
-| `Machine_Displacement` | Displacement measured by the machine                  | [mm]  | double    |           |                             |
-| `Machine_Load`         | Load measured by the machine                          | [N]   | double    |           |                             |
-| `MD_index--#`          | index for the measurement, e.g. image number          | [-]   | int       |           | y                           |
-| `MD_time--#`           | Time recored by the measuring device                  | [-]   | string    |           | y                           |
-| `MD_N_cycles--#`       | Number of cycles from measuring device                | [-]   | int       |           | y                           |
-| `MD_Displacement--#`   | Displacement from measuring device                    | [mm]  | double    |           | y                           |
-| `MD_Load--#`           | Load from measuring device                            | [N]   | double    |           | y                           |
-| `u--#`                 | Displacement measured along main axis at point #      | [mm]  | double    |           | y                           |
-| `v--#`                 | Displacement measured along secondary axis at point # | [mm]  | double    |           | y                           |
-| `exx--#`               | Strain measured along main axis at point #            | [-]   | double    |           | y                           |
-| `eyy--#`               | Strain measured along secondary axis at point #       | [-]   | double    |           | y                           |
-| `exy--#`               | Strain measured along a specified axis at point #     | [-]   | double    |           | y                           |
-| `Crack_length`         | Crack length measurement (for fracture testings)      | [mm]  | double    |           |                             |
-| `Crack_N_cycles`       | Number of cycles at measured crack length             | [mm]  | double    |           |                             |
-| `Crack_Displacement`   | Displacement at measured crack length                 | [mm]  | double    |           |                             |
-| `Crack_Load`           | Load at measured crack length                         | [N]   | double    |           |                             |
-| `Th_time`              | Time as counted by temperature monitoring             | [sec] | int       |           |                             |
-| `Th_N_cycles`          | Number of cycles counted by temperature monitoring    | [-]   | int       |           |                             |
-| `Th_specimen_max`      | Maximum temperature monitored                         | [°C]  | double    |           |                             |
-| `Th_specimen_mean`     | Mean temperature                                      | [°C]  | double    |           |                             |
-| `Th_chamber`           | Temperature of the test environment                   | [°C]  | double    |           |                             |
-| `Th_uppergrips`        | Temperature of the upper grips                        | [°C]  | double    |           |                             |
-| `Th_lowergrips`        | Temperature of the lower grips                        | [°C]  | double    |           |                             |
-| `T--#`                 | Temperature at point #                                | [°C]  | double    |           | y                           |
-| `Storage_modulus`      | Storage modulus measured from DMA                     | [GPa] | double    |           |                             |
-| `Tan_delta`            | Tan delta measured from DMA                           | [-]   | double    |           |                             |
-| `Specimen_name`        | Name of the specimen                                  | [-]   | string    |           |                             |
+| Column name            | Description                                           | Unit    | Data type | Mandatory | Multiple measurement points |
+| ---------------------- | ----------------------------------------------------- | ------- | --------- | --------- | --------------------------- |
+| `Machine_Time`         | Absolute or relative time recorded by the machine     | `[-]`   | string    |           |                             |
+| `Machine_N_cycles`     | Number of cycles counted by the machine               | `[-]`   | int       |           |                             |
+| `Machine_Displacement` | Displacement measured by the machine                  | `[mm]`  | double    |           |                             |
+| `Machine_Load`         | Load measured by the machine                          | `[N]`   | double    |           |                             |
+| `MD_index--#`          | index for the measurement, e.g. image number          | `[-]`   | int       |           | y                           |
+| `MD_time--#`           | Time recored by the measuring device                  | `[-]`   | string    |           | y                           |
+| `MD_N_cycles--#`       | Number of cycles from measuring device                | `[-]`   | int       |           | y                           |
+| `MD_Displacement--#`   | Displacement from measuring device                    | `[mm]`  | double    |           | y                           |
+| `MD_Load--#`           | Load from measuring device                            | `[N]`   | double    |           | y                           |
+| `u--#`                 | Displacement measured along main axis at point #      | `[mm]`  | double    |           | y                           |
+| `v--#`                 | Displacement measured along secondary axis at point # | `[mm]`  | double    |           | y                           |
+| `exx--#`               | Strain measured along main axis at point #            | `[-]`   | double    |           | y                           |
+| `eyy--#`               | Strain measured along secondary axis at point #       | `[-]`   | double    |           | y                           |
+| `exy--#`               | Strain measured along a specified axis at point #     | `[-]`   | double    |           | y                           |
+| `Crack_length`         | Crack length measurement (for fracture testings)      | `[mm]`  | double    |           |                             |
+| `Crack_N_cycles`       | Number of cycles at measured crack length             | `[mm]`  | double    |           |                             |
+| `Crack_Displacement`   | Displacement at measured crack length                 | `[mm]`  | double    |           |                             |
+| `Crack_Load`           | Load at measured crack length                         | `[N]`   | double    |           |                             |
+| `Th_time`              | Time as counted by temperature monitoring             | `[sec]` | int       |           |                             |
+| `Th_N_cycles`          | Number of cycles counted by temperature monitoring    | `[-]`   | int       |           |                             |
+| `Th_specimen_max`      | Maximum temperature monitored                         | `[°C]`  | double    |           |                             |
+| `Th_specimen_mean`     | Mean temperature                                      | `[°C]`  | double    |           |                             |
+| `Th_chamber`           | Temperature of the test environment                   | `[°C]`  | double    |           |                             |
+| `Th_uppergrips`        | Temperature of the upper grips                        | `[°C]`  | double    |           |                             |
+| `Th_lowergrips`        | Temperature of the lower grips                        | `[°C]`  | double    |           |                             |
+| `T--#`                 | Temperature at point #                                | `[°C]`  | double    |           | y                           |
+| `Storage_modulus`      | Storage modulus measured from DMA                     | `[GPa]` | double    |           |                             |
+| `Tan_delta`            | Tan delta measured from DMA                           | `[-]`   | double    |           |                             |
+| `Specimen_name`        | Name of the specimen                                  | `[-]`   | string    |           |                             |
 
 ### `FA` without fracture specifities :
 

--- a/Data/variables_dictionary.md
+++ b/Data/variables_dictionary.md
@@ -1,23 +1,23 @@
-| Variable name         | Description                                             | Symbol      | Unit    | Data type | Used in                 |
-| --------------------- | ------------------------------------------------------- | ----------- | ------- | --------- | ----------------------- |
-| a                     | S-N Curve parameter                                     | A           | [-]     | double    | SNC                     |
-| b                     | S-N Curve parameter                                     | B           | [1/MPa] | double    | SNC                     |
-| confidence_interval   | Confidence bounds (usually 5, 95%)                      | rsql        | %       | double    | SNC, FAF                |
-| cum_n_cycles          | percentage                                              |             |         | double    | CYC                     |
-| cycles_to_failure     | Number of cycles to failure                             | N           | [-]     | int       | AGG, SNC, CLD, FAF      |
-| damage                | Damage                                                  | D           | [-]     | double    | DAS                     |
-| fp                    | Linearity criterion                                     | Fp          | [?]     | double    | SNC                     |
-| lrsq                  | ?                                                       | LRSQ        | [?]     | double    | SNC                     |
-| n_cycles              | Number of cycles                                        | n           |         | double    | CYC                     |
-| off_axis_angle1       | ?                                                       |             | [°]     | double    | FAF                     |
-| off_axis_angle2       | ?                                                       |             | [°]     | double    | FAF                     |
-| reliability_level     | Reliability level                                       | P(N)        | %       | double    | AGG                     |
-| residual_strength     | Residual strength                                       | sigma_r     | [MPa]   | double    | AGG                     |
-| stress_amplitude      | Stress amplitude                                        | sigma_a     | [MPa]   | double    | CLD                     |
-| stress_cluster_number | Index of the cluster of stress level for Whitney method |             | [-]     | int       | AGG                     |
-| stress_lowerbound     | Stress at failure (lower bound)                         | sigma_max   | [MPa]   | double    | SNC                     |
-| stress_max            | Max stress                                              | sigma_max   | [MPa]   | double    | LDS, SNC, AGG, FAF, DAS |
-| stress_mean           | Mean stress                                             | sigma_mean  | [MPa]   | double    | CLD, CYC                |
-| stress_range          | Stress range (= 2 * sigma_a)                            | delta_sigma | [MPa]   | double    | CYC                     |
-| stress_ratio          | Stress ratio                                            | R           | [-]     | double    | AGG, SNC, FAF, CYC      |
-| stress_upperbound     | Stress at failure (upper bound)                         | sigma_max   | [MPa]   | double    | SNC                     |
+| Variable name         | Description                                             | Symbol      | Unit      | Data type | Used in                 |
+| --------------------- | ------------------------------------------------------- | ----------- | --------- | --------- | ----------------------- |
+| a                     | S-N Curve parameter                                     | A           | `[-]`     | double    | SNC                     |
+| b                     | S-N Curve parameter                                     | B           | `[1/MPa]` | double    | SNC                     |
+| confidence_interval   | Confidence bounds (usually 5, 95%)                      | rsql        | %         | double    | SNC, FAF                |
+| cum_n_cycles          | percentage                                              |             |           | double    | CYC                     |
+| cycles_to_failure     | Number of cycles to failure                             | N           | `[-]`     | int       | AGG, SNC, CLD, FAF      |
+| damage                | Damage                                                  | D           | `[-]`     | double    | DAS                     |
+| fp                    | Linearity criterion                                     | Fp          | `[?]`     | double    | SNC                     |
+| lrsq                  | ?                                                       | LRSQ        | `[?]`     | double    | SNC                     |
+| n_cycles              | Number of cycles                                        | n           |           | double    | CYC                     |
+| off_axis_angle1       | ?                                                       |             | `[°]`     | double    | FAF                     |
+| off_axis_angle2       | ?                                                       |             | `[°]`     | double    | FAF                     |
+| reliability_level     | Reliability level                                       | P(N)        | %         | double    | AGG                     |
+| residual_strength     | Residual strength                                       | sigma_r     | `[MPa]`   | double    | AGG                     |
+| stress_amplitude      | Stress amplitude                                        | sigma_a     | `[MPa]`   | double    | CLD                     |
+| stress_cluster_number | Index of the cluster of stress level for Whitney method |             | `[-]`     | int       | AGG                     |
+| stress_lowerbound     | Stress at failure (lower bound)                         | sigma_max   | `[MPa]`   | double    | SNC                     |
+| stress_max            | Max stress                                              | sigma_max   | `[MPa]`   | double    | LDS, SNC, AGG, FAF, DAS |
+| stress_mean           | Mean stress                                             | sigma_mean  | `[MPa]`   | double    | CLD, CYC                |
+| stress_range          | Stress range (= `2 * sigma_a`)                          | delta_sigma | `[MPa]`   | double    | CYC                     |
+| stress_ratio          | Stress ratio                                            | R           | `[-]`     | double    | AGG, SNC, FAF, CYC      |
+| stress_upperbound     | Stress at failure (upper bound)                         | sigma_max   | `[MPa]`   | double    | SNC                     |

--- a/backend/.pre-commit-config.yaml
+++ b/backend/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
-files: \.(py|yaml|yml)$
+files: \.(py|yaml|yml|md)$
 exclude: ^traefik\.yaml$
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -23,3 +23,9 @@ repos:
     hooks:
       - id: isort
         name: isort (python)
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: "v3.0.0-alpha.4"
+    hooks:
+      - id: prettier
+        name: prettier (markdown)
+        types: [markdown]


### PR DESCRIPTION
- add prettier for markdown to pre-commit
- change \[unit\] into \`\[unit\]\` in data conventions
- re-commit all data conventions
